### PR TITLE
Update: isEmpty 验证规则

### DIFF
--- a/src/w5cValidator.js
+++ b/src/w5cValidator.js
@@ -16,7 +16,7 @@ angular.module("w5c.validator", ["ng"])
             this.elemTypes = elemTypes;
             this.rules = [];
             this.isEmpty = function (object) {
-                if (object === undefined || object === null) {
+                if (!object) {
                     return true;
                 }
                 if (object instanceof Array && object.length === 0) {


### PR DESCRIPTION
原来: isEmpty 会把空字符串当成有效字符来检验，导致表单中存在没设置 name 的字段的时候会出异常。
改为: lodash 的 isEmpty 判断方式，当 !object 的时候表示空。
