### PR TITLE
Update w5cValidator.js

### DIFF
--- a/dist/w5cValidator.js
+++ b/dist/w5cValidator.js
@@ -33,13 +33,20 @@ angular.module("w5c.validator", ["ng"])
                 var $elem = angular.element(elem),
                     $parent = $elem.parent(),
                     $group = $parent.parent();
+                    
+                //找到 form-group，及其下级
+                while(!$group.hasClass("form-group"))
+                {
+                    $parent = $parent.parent();
+                    $group = $parent.parent();
+                }
 
                 if(!this.isEmpty($group) && $group[0].tagName === "FORM"){
                     $group = $parent;
                 }
                 if (!this.isEmpty($group) && !$group.hasClass("has-error")) {
                     $group.addClass("has-error");
-                    $elem.after('<span class="w5c-error">' + errorMessages[0] + '</span>');
+                    $parent.append('<span class="w5c-error">' + errorMessages[0] + '</span>');
                 }
             };
             this.defaultRemoveError = function (elem) {


### PR DESCRIPTION
当 <input> 框为 <div class="input-group"> 组合框时：
1、错误提示信息错位。
2、control-label 不红色显示。

修改代码，查找父级，直至找到 "form-group" 为止，并修改 "w5c-error" 的插入方式。