### PR TITLE
w5c-dynamic-element 与 w5c-repeat 合用时特殊情况下出错的修复

### DIFF
--- a/src/directive.js
+++ b/src/directive.js
@@ -201,28 +201,30 @@
                 }
             };
         }])
-        .directive("w5cRepeat", [function () {
+        .directive("w5cRepeat", ['$timeout', function ($timeout) {
             'use strict';
             return {
                 require: ["ngModel", "^w5cFormValidate"],
                 link   : function (scope, elem, attrs, ctrls) {
-                    var otherInput = elem.inheritedData("$formController")[attrs.w5cRepeat];
-                    var ngModel = ctrls[0], w5cFormCtrl = ctrls[1];
-                    ngModel.$parsers.push(function (value) {
-                        if (value === otherInput.$viewValue) {
-                            ngModel.$setValidity("repeat", true);
-                        } else {
-                            ngModel.$setValidity("repeat", false);
-                        }
-                        return value;
-                    });
+                    $timeout(function(){
+                        var otherInput = elem.inheritedData("$formController")[attrs.w5cRepeat];
+                        var ngModel = ctrls[0], w5cFormCtrl = ctrls[1];
+                        ngModel.$parsers.push(function (value) {
+                            if (value === otherInput.$viewValue) {
+                                ngModel.$setValidity("repeat", true);
+                            } else {
+                                ngModel.$setValidity("repeat", false);
+                            }
+                            return value;
+                        });
 
-                    otherInput.$parsers.push(function (value) {
-                        ngModel.$setValidity("repeat", value === ngModel.$viewValue);
-                        if (value === ngModel.$viewValue) {
-                            w5cFormCtrl.removeError(elem);
-                        }
-                        return value;
+                        otherInput.$parsers.push(function (value) {
+                            ngModel.$setValidity("repeat", value === ngModel.$viewValue);
+                            if (value === ngModel.$viewValue) {
+                                w5cFormCtrl.removeError(elem);
+                            }
+                            return value;
+                        });
                     });
                 }
             };


### PR DESCRIPTION
当 form 中存在多个 w5c-dynamic-element 元素（外层被包裹 ng-if），并且 w5c-repeat 所指的元素不是第一个 w5c-dynamic-element 时，会出现错误，原因是 var otherInput = elem.inheritedData("$formController")[attrs.w5cRepeat]; 取出的对象为空，加上 $timeout 后问题即可解决。