### PR TITLE
解决与其他input插件的冲突

### DIFF
--- a/src/w5cValidator.js
+++ b/src/w5cValidator.js
@@ -49,8 +49,7 @@
                         $group.addClass("has-error");
 
                     }
-                    var $next = $elem.next();
-                    if (!$next || !$next.hasClass("w5c-error")) {
+                    if($elem.siblings(".w5c-error").length===0){
                         $elem.after('<span class="w5c-error">' + errorMessages[0] + '</span>');
                     }
                 };
@@ -61,9 +60,9 @@
                     if (!this.isEmpty($group) && $group.hasClass("has-error")) {
                         $group.removeClass("has-error");
                     }
-                    var $next = $elem.next();
-                    if ($next.hasClass && $next.hasClass("w5c-error")) {
-                        $next.remove();
+                    $errorSiblings=$elem.siblings(".w5c-error");
+                    if($errorSiblings.length>0){
+                        $errorSiblings.remove();
                     }
 
                 };


### PR DESCRIPTION
在用angular-strap的typeahead
预先输入等其他input插件的时候，会在input后面插入一个div用于临时展示，通过寻找siblings而不是next可以修复这个问题。
~第一次pull request。。